### PR TITLE
Make compatible with ProGet 5.0

### DIFF
--- a/VorSecurity.csproj
+++ b/VorSecurity.csproj
@@ -30,23 +30,28 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="InedoLib, Version=478.1.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
-      <HintPath>packages\Inedo.ProGet.SDK.4.6.1\lib\net45\InedoLib.dll</HintPath>
+    <Reference Include="Inedo.Agents.Client, Version=516.0.0.0, Culture=neutral, PublicKeyToken=9de986a2f8db80fc, processorArchitecture=MSIL">
+      <HintPath>packages\Inedo.SDK.0.1.0-pre0049\lib\net45\Inedo.Agents.Client.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Inedo.ExecutionEngine, Version=63.1.0.0, Culture=neutral, PublicKeyToken=68703f0e52007e75, processorArchitecture=MSIL">
+      <HintPath>packages\Inedo.SDK.0.1.0-pre0049\lib\net45\Inedo.ExecutionEngine.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProGet.Web.Controls, Version=4.6.0.32, Culture=neutral, PublicKeyToken=20535527eaf4e568, processorArchitecture=MSIL">
-      <HintPath>packages\Inedo.ProGet.SDK.4.6.1\lib\net45\ProGet.Web.Controls.dll</HintPath>
+    <Reference Include="Inedo.SDK, Version=0.1.0.0, Culture=neutral, PublicKeyToken=29fae5dec3001603, processorArchitecture=MSIL">
+      <HintPath>packages\Inedo.SDK.0.1.0-pre0049\lib\net45\Inedo.SDK.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
-    <Reference Include="ProGetCore, Version=4.6.0.32, Culture=neutral, PublicKeyToken=20535527eaf4e568, processorArchitecture=MSIL">
-      <HintPath>packages\Inedo.ProGet.SDK.4.6.1\lib\net45\ProGetCore.dll</HintPath>
+    <Reference Include="InedoLib, Version=516.0.0.0, Culture=neutral, PublicKeyToken=112cfb71329714a6, processorArchitecture=MSIL">
+      <HintPath>packages\Inedo.SDK.0.1.0-pre0049\lib\net45\InedoLib.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
+      <Private>False</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
       <SpecificVersion>False</SpecificVersion>
       <Private>False</Private>
     </Reference>
@@ -64,7 +69,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>powershell -Command "if (Test-Path C:\Projects\ProGet\Extensions -PathType Container) { Compress-Archive -Path '$(TargetDir)*' -DestinationPath C:\Projects\ProGet\Extensions\$(TargetName).zip -Force; Move-Item C:\Projects\ProGet\Extensions\$(TargetName).zip -Destination C:\Projects\ProGet\Extensions\$(TargetName).progetx -Force }</PostBuildEvent>
+    <PostBuildEvent>powershell -Command "if (Test-Path C:\Projects\ProGet\Extensions -PathType Container) { Compress-Archive -Path '$(TargetDir)*' -DestinationPath C:\Projects\ProGet\Extensions\$(TargetName).zip -Force; Move-Item C:\Projects\ProGet\Extensions\$(TargetName).zip -Destination C:\Projects\ProGet\Extensions\$(TargetName).inedox -Force }</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/VulnerabilitySources/VorSecurityVulnerabilitySource.cs
+++ b/VulnerabilitySources/VorSecurityVulnerabilitySource.cs
@@ -10,9 +10,9 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Inedo.Diagnostics;
 using Inedo.Documentation;
+using Inedo.Extensibility.VulnerabilitySources;
+using Inedo.Feeds;
 using Inedo.IO;
-using Inedo.ProGet.Extensibility.VulnerabilitySources;
-using Inedo.ProGet.Feeds;
 using Inedo.Serialization;
 using Newtonsoft.Json;
 

--- a/packages.config
+++ b/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Inedo.ProGet.SDK" version="4.6.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="Inedo.SDK" version="0.1.0-pre0049" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
We might want to split this into a shared project with two csproj files that build for either Inedo.ProGet.SDK or Inedo.SDK instead.

Fixes #2.